### PR TITLE
Fix #4 VarintのフォーマットをBitCoin類似のフォーマットへ変更した。

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <!--<NullableContextOptions>enable</NullableContextOptions>-->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/perf/FormatterBenchmarks/FormatterBenchmarks.csproj
+++ b/perf/FormatterBenchmarks/FormatterBenchmarks.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.4" />
     <PackageReference Include="MessagePack" Version="1.7.3.4" />
   </ItemGroup>
 

--- a/perf/FormatterBenchmarks/Internal/BenchmarkConfig.cs
+++ b/perf/FormatterBenchmarks/Internal/BenchmarkConfig.cs
@@ -1,7 +1,9 @@
 ﻿using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Diagnostics.Windows;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.CsProj;
 
 namespace FormatterBenchmarks.Internal
 {
@@ -11,8 +13,8 @@ namespace FormatterBenchmarks.Internal
         {
             this.Add(MarkdownExporter.GitHub);
             this.Add(MemoryDiagnoser.Default);
-
-            this.Add(Job.ShortRun.With(BenchmarkDotNet.Environments.Platform.X64));
+            this.Add(Job.ShortRun.With(BenchmarkDotNet.Environments.Platform.X64).With(CsProjCoreToolchain.NetCoreApp21));
+            //this.Add(new EtwProfiler());
         }
     }
 }

--- a/perf/FormatterBenchmarks/Program.cs
+++ b/perf/FormatterBenchmarks/Program.cs
@@ -1,6 +1,8 @@
 ﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnostics.Windows;
 using BenchmarkDotNet.Running;
 using FormatterBenchmarks.Cases;
+using FormatterBenchmarks.Internal;
 
 namespace FormatterBenchmarks
 {

--- a/perf/FormatterBenchmarks/_RocketPack/Messages.generated.cs
+++ b/perf/FormatterBenchmarks/_RocketPack/Messages.generated.cs
@@ -60,15 +60,15 @@ namespace FormatterBenchmarks
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (!value.Bytes.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Bytes
                 if (!value.Bytes.IsEmpty)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.Bytes.Span);
                 }
             }
@@ -78,13 +78,13 @@ namespace FormatterBenchmarks
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IMemoryOwner<byte> p_bytes = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Bytes
@@ -153,16 +153,16 @@ namespace FormatterBenchmarks
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.List.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // List
                 if (value.List.Count != 0)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.List.Count);
+                    w.Write((uint)0);
+                    w.Write((uint)value.List.Count);
                     foreach (var n in value.List)
                     {
                         RocketPack_IntPropertiesMessage.Formatter.Serialize(w, n, rank + 1);
@@ -175,18 +175,18 @@ namespace FormatterBenchmarks
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IList<RocketPack_IntPropertiesMessage> p_list = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // List
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_list = new RocketPack_IntPropertiesMessage[length];
                                 for (int i = 0; i < p_list.Count; i++)
                                 {
@@ -255,16 +255,16 @@ namespace FormatterBenchmarks
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.List.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // List
                 if (value.List.Count != 0)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.List.Count);
+                    w.Write((uint)0);
+                    w.Write((uint)value.List.Count);
                     foreach (var n in value.List)
                     {
                         RocketPack_StringPropertiesMessage.Formatter.Serialize(w, n, rank + 1);
@@ -277,18 +277,18 @@ namespace FormatterBenchmarks
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IList<RocketPack_StringPropertiesMessage> p_list = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // List
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_list = new RocketPack_StringPropertiesMessage[length];
                                 for (int i = 0; i < p_list.Count; i++)
                                 {
@@ -376,7 +376,7 @@ namespace FormatterBenchmarks
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.MyProperty1 != default) propertyCount++;
                     if (value.MyProperty2 != default) propertyCount++;
                     if (value.MyProperty3 != default) propertyCount++;
@@ -386,62 +386,62 @@ namespace FormatterBenchmarks
                     if (value.MyProperty7 != default) propertyCount++;
                     if (value.MyProperty8 != default) propertyCount++;
                     if (value.MyProperty9 != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // MyProperty1
                 if (value.MyProperty1 != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.MyProperty1);
+                    w.Write((uint)0);
+                    w.Write(value.MyProperty1);
                 }
                 // MyProperty2
                 if (value.MyProperty2 != default)
                 {
-                    w.Write((ulong)1);
-                    w.Write((ulong)value.MyProperty2);
+                    w.Write((uint)1);
+                    w.Write(value.MyProperty2);
                 }
                 // MyProperty3
                 if (value.MyProperty3 != default)
                 {
-                    w.Write((ulong)2);
-                    w.Write((ulong)value.MyProperty3);
+                    w.Write((uint)2);
+                    w.Write(value.MyProperty3);
                 }
                 // MyProperty4
                 if (value.MyProperty4 != default)
                 {
-                    w.Write((ulong)3);
-                    w.Write((ulong)value.MyProperty4);
+                    w.Write((uint)3);
+                    w.Write(value.MyProperty4);
                 }
                 // MyProperty5
                 if (value.MyProperty5 != default)
                 {
-                    w.Write((ulong)4);
-                    w.Write((ulong)value.MyProperty5);
+                    w.Write((uint)4);
+                    w.Write(value.MyProperty5);
                 }
                 // MyProperty6
                 if (value.MyProperty6 != default)
                 {
-                    w.Write((ulong)5);
-                    w.Write((ulong)value.MyProperty6);
+                    w.Write((uint)5);
+                    w.Write(value.MyProperty6);
                 }
                 // MyProperty7
                 if (value.MyProperty7 != default)
                 {
-                    w.Write((ulong)6);
-                    w.Write((ulong)value.MyProperty7);
+                    w.Write((uint)6);
+                    w.Write(value.MyProperty7);
                 }
                 // MyProperty8
                 if (value.MyProperty8 != default)
                 {
-                    w.Write((ulong)7);
-                    w.Write((ulong)value.MyProperty8);
+                    w.Write((uint)7);
+                    w.Write(value.MyProperty8);
                 }
                 // MyProperty9
                 if (value.MyProperty9 != default)
                 {
-                    w.Write((ulong)8);
-                    w.Write((ulong)value.MyProperty9);
+                    w.Write((uint)8);
+                    w.Write(value.MyProperty9);
                 }
             }
 
@@ -450,7 +450,7 @@ namespace FormatterBenchmarks
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 uint p_myProperty1 = default;
                 uint p_myProperty2 = default;
@@ -464,52 +464,52 @@ namespace FormatterBenchmarks
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // MyProperty1
                             {
-                                p_myProperty1 = (uint)r.GetUInt64();
+                                p_myProperty1 = r.GetUInt32();
                                 break;
                             }
                         case 1: // MyProperty2
                             {
-                                p_myProperty2 = (uint)r.GetUInt64();
+                                p_myProperty2 = r.GetUInt32();
                                 break;
                             }
                         case 2: // MyProperty3
                             {
-                                p_myProperty3 = (uint)r.GetUInt64();
+                                p_myProperty3 = r.GetUInt32();
                                 break;
                             }
                         case 3: // MyProperty4
                             {
-                                p_myProperty4 = (uint)r.GetUInt64();
+                                p_myProperty4 = r.GetUInt32();
                                 break;
                             }
                         case 4: // MyProperty5
                             {
-                                p_myProperty5 = (uint)r.GetUInt64();
+                                p_myProperty5 = r.GetUInt32();
                                 break;
                             }
                         case 5: // MyProperty6
                             {
-                                p_myProperty6 = (uint)r.GetUInt64();
+                                p_myProperty6 = r.GetUInt32();
                                 break;
                             }
                         case 6: // MyProperty7
                             {
-                                p_myProperty7 = (uint)r.GetUInt64();
+                                p_myProperty7 = r.GetUInt32();
                                 break;
                             }
                         case 7: // MyProperty8
                             {
-                                p_myProperty8 = (uint)r.GetUInt64();
+                                p_myProperty8 = r.GetUInt32();
                                 break;
                             }
                         case 8: // MyProperty9
                             {
-                                p_myProperty9 = (uint)r.GetUInt64();
+                                p_myProperty9 = r.GetUInt32();
                                 break;
                             }
                     }
@@ -579,29 +579,29 @@ namespace FormatterBenchmarks
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.MyProperty1 != default) propertyCount++;
                     if (value.MyProperty2 != default) propertyCount++;
                     if (value.MyProperty3 != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // MyProperty1
                 if (value.MyProperty1 != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.MyProperty1);
                 }
                 // MyProperty2
                 if (value.MyProperty2 != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write(value.MyProperty2);
                 }
                 // MyProperty3
                 if (value.MyProperty3 != default)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.MyProperty3);
                 }
             }
@@ -611,7 +611,7 @@ namespace FormatterBenchmarks
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 string p_myProperty1 = default;
                 string p_myProperty2 = default;
@@ -619,7 +619,7 @@ namespace FormatterBenchmarks
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // MyProperty1

--- a/src/Omnix.Base/Omnix.Base.csproj
+++ b/src/Omnix.Base/Omnix.Base.csproj
@@ -4,14 +4,13 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>2018.8.31.34</AssemblyVersion>
     <AssemblyName>Omnix.Base</AssemblyName>
     <RootNamespace>Omnix.Base</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.5.11" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Omnix.Collections/Omnix.Collections.csproj
+++ b/src/Omnix.Collections/Omnix.Collections.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Omnix.Cryptography/Omnix.Cryptography.csproj
+++ b/src/Omnix.Cryptography/Omnix.Cryptography.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Omnix.Cryptography/_RocketPack/Messages.generated.cs
+++ b/src/Omnix.Cryptography/_RocketPack/Messages.generated.cs
@@ -179,36 +179,36 @@ namespace Omnix.Cryptography
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.CreationTime != default) propertyCount++;
                     if (value.AlgorithmType != default) propertyCount++;
                     if (!value.PublicKey.IsEmpty) propertyCount++;
                     if (!value.PrivateKey.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // CreationTime
                 if (value.CreationTime != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.CreationTime);
                 }
                 // AlgorithmType
                 if (value.AlgorithmType != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write((ulong)value.AlgorithmType);
                 }
                 // PublicKey
                 if (!value.PublicKey.IsEmpty)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.PublicKey.Span);
                 }
                 // PrivateKey
                 if (!value.PrivateKey.IsEmpty)
                 {
-                    w.Write((ulong)3);
+                    w.Write((uint)3);
                     w.Write(value.PrivateKey.Span);
                 }
             }
@@ -218,7 +218,7 @@ namespace Omnix.Cryptography
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 Timestamp p_creationTime = default;
                 OmniAgreementAlgorithmType p_algorithmType = default;
@@ -227,7 +227,7 @@ namespace Omnix.Cryptography
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // CreationTime
@@ -310,29 +310,29 @@ namespace Omnix.Cryptography
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.CreationTime != default) propertyCount++;
                     if (value.AlgorithmType != default) propertyCount++;
                     if (!value.PublicKey.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // CreationTime
                 if (value.CreationTime != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.CreationTime);
                 }
                 // AlgorithmType
                 if (value.AlgorithmType != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write((ulong)value.AlgorithmType);
                 }
                 // PublicKey
                 if (!value.PublicKey.IsEmpty)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.PublicKey.Span);
                 }
             }
@@ -342,7 +342,7 @@ namespace Omnix.Cryptography
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 Timestamp p_creationTime = default;
                 OmniAgreementAlgorithmType p_algorithmType = default;
@@ -350,7 +350,7 @@ namespace Omnix.Cryptography
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // CreationTime
@@ -428,29 +428,29 @@ namespace Omnix.Cryptography
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.CreationTime != default) propertyCount++;
                     if (value.AlgorithmType != default) propertyCount++;
                     if (!value.PrivateKey.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // CreationTime
                 if (value.CreationTime != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.CreationTime);
                 }
                 // AlgorithmType
                 if (value.AlgorithmType != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write((ulong)value.AlgorithmType);
                 }
                 // PrivateKey
                 if (!value.PrivateKey.IsEmpty)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.PrivateKey.Span);
                 }
             }
@@ -460,7 +460,7 @@ namespace Omnix.Cryptography
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 Timestamp p_creationTime = default;
                 OmniAgreementAlgorithmType p_algorithmType = default;
@@ -468,7 +468,7 @@ namespace Omnix.Cryptography
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // CreationTime
@@ -555,36 +555,36 @@ namespace Omnix.Cryptography
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Name != default) propertyCount++;
                     if (value.AlgorithmType != default) propertyCount++;
                     if (!value.PublicKey.IsEmpty) propertyCount++;
                     if (!value.PrivateKey.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Name
                 if (value.Name != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.Name);
                 }
                 // AlgorithmType
                 if (value.AlgorithmType != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write((ulong)value.AlgorithmType);
                 }
                 // PublicKey
                 if (!value.PublicKey.IsEmpty)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.PublicKey.Span);
                 }
                 // PrivateKey
                 if (!value.PrivateKey.IsEmpty)
                 {
-                    w.Write((ulong)3);
+                    w.Write((uint)3);
                     w.Write(value.PrivateKey.Span);
                 }
             }
@@ -594,7 +594,7 @@ namespace Omnix.Cryptography
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 string p_name = default;
                 OmniDigitalSignatureAlgorithmType p_algorithmType = default;
@@ -603,7 +603,7 @@ namespace Omnix.Cryptography
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Name
@@ -695,36 +695,36 @@ namespace Omnix.Cryptography
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Name != default) propertyCount++;
                     if (value.AlgorithmType != default) propertyCount++;
                     if (!value.PublicKey.IsEmpty) propertyCount++;
                     if (!value.Value.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Name
                 if (value.Name != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.Name);
                 }
                 // AlgorithmType
                 if (value.AlgorithmType != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write((ulong)value.AlgorithmType);
                 }
                 // PublicKey
                 if (!value.PublicKey.IsEmpty)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.PublicKey.Span);
                 }
                 // Value
                 if (!value.Value.IsEmpty)
                 {
-                    w.Write((ulong)3);
+                    w.Write((uint)3);
                     w.Write(value.Value.Span);
                 }
             }
@@ -734,7 +734,7 @@ namespace Omnix.Cryptography
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 string p_name = default;
                 OmniDigitalSignatureAlgorithmType p_algorithmType = default;
@@ -743,7 +743,7 @@ namespace Omnix.Cryptography
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Name
@@ -822,22 +822,22 @@ namespace Omnix.Cryptography
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Name != default) propertyCount++;
                     if (value.Hash != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Name
                 if (value.Name != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.Name);
                 }
                 // Hash
                 if (value.Hash != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     OmniHash.Formatter.Serialize(w, value.Hash, rank + 1);
                 }
             }
@@ -847,14 +847,14 @@ namespace Omnix.Cryptography
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 string p_name = default;
                 OmniHash p_hash = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Name
@@ -923,22 +923,22 @@ namespace Omnix.Cryptography
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.AlgorithmType != default) propertyCount++;
                     if (!value.Key.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // AlgorithmType
                 if (value.AlgorithmType != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write((ulong)value.AlgorithmType);
                 }
                 // Key
                 if (!value.Key.IsEmpty)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write(value.Key.Span);
                 }
             }
@@ -948,14 +948,14 @@ namespace Omnix.Cryptography
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 OmniHashcashAlgorithmType p_algorithmType = default;
                 ReadOnlyMemory<byte> p_key = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // AlgorithmType

--- a/src/Omnix.Network.Connection/Multiplexer/Internal/_RocketPack/Messages.generated.cs
+++ b/src/Omnix.Network.Connection/Multiplexer/Internal/_RocketPack/Messages.generated.cs
@@ -63,16 +63,16 @@ namespace Omnix.Network.Connection.Multiplexer.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Versions.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Versions
                 if (value.Versions.Count != 0)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.Versions.Count);
+                    w.Write((uint)0);
+                    w.Write((uint)value.Versions.Count);
                     foreach (var n in value.Versions)
                     {
                         w.Write((ulong)n);
@@ -85,18 +85,18 @@ namespace Omnix.Network.Connection.Multiplexer.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IList<CommunicatorVersion> p_versions = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Versions
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_versions = new CommunicatorVersion[length];
                                 for (int i = 0; i < p_versions.Count; i++)
                                 {

--- a/src/Omnix.Network.Connection/Multiplexer/V1/Internal/_RocketPack/Messages.generated.cs
+++ b/src/Omnix.Network.Connection/Multiplexer/V1/Internal/_RocketPack/Messages.generated.cs
@@ -60,23 +60,23 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.InitialWindowSize != default) propertyCount++;
                     if (value.MaxSessionAcceptQueueSize != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // InitialWindowSize
                 if (value.InitialWindowSize != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.InitialWindowSize);
+                    w.Write((uint)0);
+                    w.Write(value.InitialWindowSize);
                 }
                 // MaxSessionAcceptQueueSize
                 if (value.MaxSessionAcceptQueueSize != default)
                 {
-                    w.Write((ulong)1);
-                    w.Write((ulong)value.MaxSessionAcceptQueueSize);
+                    w.Write((uint)1);
+                    w.Write(value.MaxSessionAcceptQueueSize);
                 }
             }
 
@@ -85,24 +85,24 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ulong p_initialWindowSize = default;
                 uint p_maxSessionAcceptQueueSize = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // InitialWindowSize
                             {
-                                p_initialWindowSize = (ulong)r.GetUInt64();
+                                p_initialWindowSize = r.GetUInt64();
                                 break;
                             }
                         case 1: // MaxSessionAcceptQueueSize
                             {
-                                p_maxSessionAcceptQueueSize = (uint)r.GetUInt64();
+                                p_maxSessionAcceptQueueSize = r.GetUInt32();
                                 break;
                             }
                     }
@@ -153,16 +153,16 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.SessionId != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // SessionId
                 if (value.SessionId != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.SessionId);
+                    w.Write((uint)0);
+                    w.Write(value.SessionId);
                 }
             }
 
@@ -171,18 +171,18 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ulong p_sessionId = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // SessionId
                             {
-                                p_sessionId = (ulong)r.GetUInt64();
+                                p_sessionId = r.GetUInt64();
                                 break;
                             }
                     }
@@ -233,16 +233,16 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.SessionId != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // SessionId
                 if (value.SessionId != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.SessionId);
+                    w.Write((uint)0);
+                    w.Write(value.SessionId);
                 }
             }
 
@@ -251,18 +251,18 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ulong p_sessionId = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // SessionId
                             {
-                                p_sessionId = (ulong)r.GetUInt64();
+                                p_sessionId = r.GetUInt64();
                                 break;
                             }
                     }
@@ -317,23 +317,23 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.SessionId != default) propertyCount++;
                     if (value.Size != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // SessionId
                 if (value.SessionId != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.SessionId);
+                    w.Write((uint)0);
+                    w.Write(value.SessionId);
                 }
                 // Size
                 if (value.Size != default)
                 {
-                    w.Write((ulong)1);
-                    w.Write((ulong)value.Size);
+                    w.Write((uint)1);
+                    w.Write(value.Size);
                 }
             }
 
@@ -342,24 +342,24 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ulong p_sessionId = default;
                 ulong p_size = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // SessionId
                             {
-                                p_sessionId = (ulong)r.GetUInt64();
+                                p_sessionId = r.GetUInt64();
                                 break;
                             }
                         case 1: // Size
                             {
-                                p_size = (ulong)r.GetUInt64();
+                                p_size = r.GetUInt64();
                                 break;
                             }
                     }
@@ -377,12 +377,12 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
             SessionDataMessage.Formatter = new CustomFormatter();
         }
 
-        public static readonly int MaxDataLength = 1048576;
+        public static readonly int MaxDataLength = 262144;
 
         public SessionDataMessage(ulong sessionId, bool isCompleted, IMemoryOwner<byte> data)
         {
             if (data is null) throw new ArgumentNullException("data");
-            if (data.Memory.Length > 1048576) throw new ArgumentOutOfRangeException("data");
+            if (data.Memory.Length > 262144) throw new ArgumentOutOfRangeException("data");
 
             this.SessionId = sessionId;
             this.IsCompleted = isCompleted;
@@ -429,29 +429,29 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.SessionId != default) propertyCount++;
                     if (value.IsCompleted != default) propertyCount++;
                     if (!value.Data.IsEmpty) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // SessionId
                 if (value.SessionId != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.SessionId);
+                    w.Write((uint)0);
+                    w.Write(value.SessionId);
                 }
                 // IsCompleted
                 if (value.IsCompleted != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write(value.IsCompleted);
                 }
                 // Data
                 if (!value.Data.IsEmpty)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.Data.Span);
                 }
             }
@@ -461,7 +461,7 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ulong p_sessionId = default;
                 bool p_isCompleted = default;
@@ -469,12 +469,12 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // SessionId
                             {
-                                p_sessionId = (ulong)r.GetUInt64();
+                                p_sessionId = r.GetUInt64();
                                 break;
                             }
                         case 1: // IsCompleted
@@ -484,7 +484,7 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                             }
                         case 2: // Data
                             {
-                                p_data = r.GetRecyclableMemory(1048576);
+                                p_data = r.GetRecyclableMemory(262144);
                                 break;
                             }
                     }
@@ -535,16 +535,16 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.SessionId != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // SessionId
                 if (value.SessionId != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.SessionId);
+                    w.Write((uint)0);
+                    w.Write(value.SessionId);
                 }
             }
 
@@ -553,18 +553,18 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ulong p_sessionId = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // SessionId
                             {
-                                p_sessionId = (ulong)r.GetUInt64();
+                                p_sessionId = r.GetUInt64();
                                 break;
                             }
                     }
@@ -619,22 +619,22 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.SessionId != default) propertyCount++;
                     if (value.ErrorType != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // SessionId
                 if (value.SessionId != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.SessionId);
+                    w.Write((uint)0);
+                    w.Write(value.SessionId);
                 }
                 // ErrorType
                 if (value.ErrorType != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write((ulong)value.ErrorType);
                 }
             }
@@ -644,19 +644,19 @@ namespace Omnix.Network.Connection.Multiplexer.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ulong p_sessionId = default;
                 SessionErrorType p_errorType = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // SessionId
                             {
-                                p_sessionId = (ulong)r.GetUInt64();
+                                p_sessionId = r.GetUInt64();
                                 break;
                             }
                         case 1: // ErrorType

--- a/src/Omnix.Network.Connection/Omnix.Network.Connection.csproj
+++ b/src/Omnix.Network.Connection/Omnix.Network.Connection.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Omnix.Network.Connection/Secure/Internal/_RocketPack/Messages.generated.cs
+++ b/src/Omnix.Network.Connection/Secure/Internal/_RocketPack/Messages.generated.cs
@@ -60,16 +60,16 @@ namespace Omnix.Network.Connection.Secure.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Versions.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Versions
                 if (value.Versions.Count != 0)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.Versions.Count);
+                    w.Write((uint)0);
+                    w.Write((uint)value.Versions.Count);
                     foreach (var n in value.Versions)
                     {
                         w.Write((ulong)n);
@@ -82,18 +82,18 @@ namespace Omnix.Network.Connection.Secure.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IList<OmniSecureConnectionVersion> p_versions = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Versions
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_versions = new OmniSecureConnectionVersion[length];
                                 for (int i = 0; i < p_versions.Count; i++)
                                 {

--- a/src/Omnix.Network.Connection/Secure/V1/Internal/_RocketPack/Messages.generated.cs
+++ b/src/Omnix.Network.Connection/Secure/V1/Internal/_RocketPack/Messages.generated.cs
@@ -128,33 +128,33 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (!value.SessionId.IsEmpty) propertyCount++;
                     if (value.AuthenticationType != default) propertyCount++;
                     if (value.KeyExchangeAlgorithms.Count != 0) propertyCount++;
                     if (value.KeyDerivationAlgorithms.Count != 0) propertyCount++;
                     if (value.CryptoAlgorithms.Count != 0) propertyCount++;
                     if (value.HashAlgorithms.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // SessionId
                 if (!value.SessionId.IsEmpty)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.SessionId.Span);
                 }
                 // AuthenticationType
                 if (value.AuthenticationType != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write((ulong)value.AuthenticationType);
                 }
                 // KeyExchangeAlgorithms
                 if (value.KeyExchangeAlgorithms.Count != 0)
                 {
-                    w.Write((ulong)2);
-                    w.Write((ulong)value.KeyExchangeAlgorithms.Count);
+                    w.Write((uint)2);
+                    w.Write((uint)value.KeyExchangeAlgorithms.Count);
                     foreach (var n in value.KeyExchangeAlgorithms)
                     {
                         w.Write((ulong)n);
@@ -163,8 +163,8 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                 // KeyDerivationAlgorithms
                 if (value.KeyDerivationAlgorithms.Count != 0)
                 {
-                    w.Write((ulong)3);
-                    w.Write((ulong)value.KeyDerivationAlgorithms.Count);
+                    w.Write((uint)3);
+                    w.Write((uint)value.KeyDerivationAlgorithms.Count);
                     foreach (var n in value.KeyDerivationAlgorithms)
                     {
                         w.Write((ulong)n);
@@ -173,8 +173,8 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                 // CryptoAlgorithms
                 if (value.CryptoAlgorithms.Count != 0)
                 {
-                    w.Write((ulong)4);
-                    w.Write((ulong)value.CryptoAlgorithms.Count);
+                    w.Write((uint)4);
+                    w.Write((uint)value.CryptoAlgorithms.Count);
                     foreach (var n in value.CryptoAlgorithms)
                     {
                         w.Write((ulong)n);
@@ -183,8 +183,8 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                 // HashAlgorithms
                 if (value.HashAlgorithms.Count != 0)
                 {
-                    w.Write((ulong)5);
-                    w.Write((ulong)value.HashAlgorithms.Count);
+                    w.Write((uint)5);
+                    w.Write((uint)value.HashAlgorithms.Count);
                     foreach (var n in value.HashAlgorithms)
                     {
                         w.Write((ulong)n);
@@ -197,7 +197,7 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ReadOnlyMemory<byte> p_sessionId = default;
                 AuthenticationType p_authenticationType = default;
@@ -208,7 +208,7 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // SessionId
@@ -223,7 +223,7 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                             }
                         case 2: // KeyExchangeAlgorithms
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_keyExchangeAlgorithms = new KeyExchangeAlgorithm[length];
                                 for (int i = 0; i < p_keyExchangeAlgorithms.Count; i++)
                                 {
@@ -233,7 +233,7 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                             }
                         case 3: // KeyDerivationAlgorithms
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_keyDerivationAlgorithms = new KeyDerivationAlgorithm[length];
                                 for (int i = 0; i < p_keyDerivationAlgorithms.Count; i++)
                                 {
@@ -243,7 +243,7 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                             }
                         case 4: // CryptoAlgorithms
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_cryptoAlgorithms = new CryptoAlgorithm[length];
                                 for (int i = 0; i < p_cryptoAlgorithms.Count; i++)
                                 {
@@ -253,7 +253,7 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                             }
                         case 5: // HashAlgorithms
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_hashAlgorithms = new HashAlgorithm[length];
                                 for (int i = 0; i < p_hashAlgorithms.Count; i++)
                                 {
@@ -316,22 +316,22 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.ProfileMessage != default) propertyCount++;
                     if (value.AgreementPublicKey != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // ProfileMessage
                 if (value.ProfileMessage != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     ProfileMessage.Formatter.Serialize(w, value.ProfileMessage, rank + 1);
                 }
                 // AgreementPublicKey
                 if (value.AgreementPublicKey != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     OmniAgreementPublicKey.Formatter.Serialize(w, value.AgreementPublicKey, rank + 1);
                 }
             }
@@ -341,14 +341,14 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 ProfileMessage p_profileMessage = default;
                 OmniAgreementPublicKey p_agreementPublicKey = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // ProfileMessage
@@ -422,16 +422,16 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Hashes.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Hashes
                 if (value.Hashes.Count != 0)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.Hashes.Count);
+                    w.Write((uint)0);
+                    w.Write((uint)value.Hashes.Count);
                     foreach (var n in value.Hashes)
                     {
                         w.Write(n.Span);
@@ -444,18 +444,18 @@ namespace Omnix.Network.Connection.Secure.V1.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IList<ReadOnlyMemory<byte>> p_hashes = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Hashes
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_hashes = new ReadOnlyMemory<byte>[length];
                                 for (int i = 0; i < p_hashes.Count; i++)
                                 {

--- a/src/Omnix.Network/_RocketPack/Messages.generated.cs
+++ b/src/Omnix.Network/_RocketPack/Messages.generated.cs
@@ -54,15 +54,15 @@ namespace Omnix.Network
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Value != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Value
                 if (value.Value != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.Value);
                 }
             }
@@ -72,13 +72,13 @@ namespace Omnix.Network
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 string p_value = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Value

--- a/src/Omnix.Remoting/_RocketPack/Messages.generated.cs
+++ b/src/Omnix.Remoting/_RocketPack/Messages.generated.cs
@@ -68,29 +68,29 @@ namespace Omnix.Remoting
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.Type != default) propertyCount++;
                     if (value.Message != default) propertyCount++;
                     if (value.StackTrace != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // Type
                 if (value.Type != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.Type);
                 }
                 // Message
                 if (value.Message != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write(value.Message);
                 }
                 // StackTrace
                 if (value.StackTrace != default)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.StackTrace);
                 }
             }
@@ -100,7 +100,7 @@ namespace Omnix.Remoting
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 string p_type = default;
                 string p_message = default;
@@ -108,7 +108,7 @@ namespace Omnix.Remoting
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // Type

--- a/src/Omnix.Serialization.RocketPack.CodeGenerator/RocketCodeGenerator.Class.cs
+++ b/src/Omnix.Serialization.RocketPack.CodeGenerator/RocketCodeGenerator.Class.cs
@@ -655,7 +655,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
 
                         w.PushIndent();
 
-                        w.WriteLine("int propertyCount = 0;");
+                        w.WriteLine("uint propertyCount = 0;");
 
                         foreach (var elementInfo in messageInfo.Elements)
                         {
@@ -694,7 +694,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                             }
                         }
 
-                        w.WriteLine($"w.Write((ulong)propertyCount);");
+                        w.WriteLine($"w.Write(propertyCount);");
 
                         w.PopIndent();
 
@@ -745,7 +745,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
 
                         w.PushIndent();
 
-                        w.WriteLine($"w.Write((ulong){elementInfo.Id});");
+                        w.WriteLine($"w.Write((uint){elementInfo.Id});");
                         this.Write_Formatter_Serialize_PropertyDef(w, "value." + elementInfo.Name, elementInfo.Type, 0);
 
                         w.PopIndent();
@@ -771,7 +771,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                     w.WriteLine();
 
                     w.WriteLine("// Read property count");
-                    w.WriteLine("int propertyCount = (int)r.GetUInt64();");
+                    w.WriteLine("uint propertyCount = r.GetUInt32();");
 
                     w.WriteLine();
 
@@ -819,7 +819,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
 
                     w.PushIndent();
 
-                    w.WriteLine("int id = (int)r.GetUInt64();");
+                    w.WriteLine("uint id = r.GetUInt32();");
                     w.WriteLine("switch (id)");
                     w.WriteLine("{");
 
@@ -876,11 +876,8 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                     case BoolTypeInfo boolTypeInfo:
                         w.WriteLine($"w.Write({name});");
                         break;
-                    case IntTypeInfo intTypeInfo when (intTypeInfo.IsSigned):
-                        w.WriteLine($"w.Write((long){name});");
-                        break;
-                    case IntTypeInfo intTypeInfo when (!intTypeInfo.IsSigned):
-                        w.WriteLine($"w.Write((ulong){name});");
+                    case IntTypeInfo intTypeInfo:
+                        w.WriteLine($"w.Write({name});");
                         break;
                     case FloatTypeInfo floatTypeInfo:
                         w.WriteLine($"w.Write({name});");
@@ -899,7 +896,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case ListTypeInfo listTypeInfo:
                         {
-                            w.WriteLine($"w.Write((ulong){name}.Count);");
+                            w.WriteLine($"w.Write((uint){name}.Count);");
                             w.WriteLine($"foreach (var n in {name})");
                             w.WriteLine("{");
 
@@ -916,7 +913,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case MapTypeInfo mapTypeInfo:
                         {
-                            w.WriteLine($"w.Write((ulong){name}.Count);");
+                            w.WriteLine($"w.Write((uint){name}.Count);");
                             w.WriteLine($"foreach (var n in {name})");
                             w.WriteLine("{");
 
@@ -964,11 +961,11 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                     case BoolTypeInfo boolTypeInfo:
                         w.WriteLine($"{name} = r.GetBoolean();");
                         break;
-                    case IntTypeInfo intTypeInfo when (intTypeInfo.IsSigned):
-                        w.WriteLine($"{name} = ({this.GetParameterTypeString(intTypeInfo)})r.GetInt64();");
-                        break;
                     case IntTypeInfo intTypeInfo when (!intTypeInfo.IsSigned):
-                        w.WriteLine($"{name} = ({this.GetParameterTypeString(intTypeInfo)})r.GetUInt64();");
+                        w.WriteLine($"{name} = r.GetUInt{intTypeInfo.Size}();");
+                        break;
+                    case IntTypeInfo intTypeInfo when (intTypeInfo.IsSigned):
+                        w.WriteLine($"{name} = r.GetInt{intTypeInfo.Size}();");
                         break;
                     case FloatTypeInfo floatTypeInfo when (floatTypeInfo.Size == 32):
                         w.WriteLine($"{name} = r.GetFloat32();");
@@ -990,7 +987,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case ListTypeInfo listTypeInfo:
                         {
-                            w.WriteLine("var length = (int)r.GetUInt64();");
+                            w.WriteLine("var length = r.GetUInt32();");
                             w.WriteLine($"{name} = new {this.GetParameterTypeString(listTypeInfo.ElementType)}[length];");
 
                             w.WriteLine($"for (int i = 0; i < {name}.Count; i++)");
@@ -1007,7 +1004,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case MapTypeInfo mapTypeInfo:
                         {
-                            w.WriteLine("var length = (int)r.GetUInt64();");
+                            w.WriteLine("var length = r.GetUInt32();");
                             w.WriteLine($"{name} = new Dictionary<{this.GetParameterTypeString(mapTypeInfo.KeyType)}, {this.GetParameterTypeString(mapTypeInfo.ValueType)}>();");
                             w.WriteLine($"{this.GetParameterTypeString(mapTypeInfo.KeyType)} t_key = default;");
                             w.WriteLine($"{this.GetParameterTypeString(mapTypeInfo.ValueType)} t_value = default;");

--- a/src/Omnix.Serialization.RocketPack.CodeGenerator/RocketCodeGenerator.Struct.cs
+++ b/src/Omnix.Serialization.RocketPack.CodeGenerator/RocketCodeGenerator.Struct.cs
@@ -791,11 +791,8 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                     case BoolTypeInfo boolTypeInfo:
                         w.WriteLine($"w.Write({name});");
                         break;
-                    case IntTypeInfo intTypeInfo when (intTypeInfo.IsSigned):
-                        w.WriteLine($"w.Write((long){name});");
-                        break;
-                    case IntTypeInfo intTypeInfo when (!intTypeInfo.IsSigned):
-                        w.WriteLine($"w.Write((ulong){name});");
+                    case IntTypeInfo intTypeInfo:
+                        w.WriteLine($"w.Write({name});");
                         break;
                     case FloatTypeInfo floatTypeInfo:
                         w.WriteLine($"w.Write({name});");
@@ -814,7 +811,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case ListTypeInfo listTypeInfo:
                         {
-                            w.WriteLine($"w.Write((ulong){name}.Count);");
+                            w.WriteLine($"w.Write((uint){name}.Count);");
                             w.WriteLine($"foreach (var n in {name})");
                             w.WriteLine("{");
 
@@ -831,7 +828,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case MapTypeInfo mapTypeInfo:
                         {
-                            w.WriteLine($"w.Write((ulong){name}.Count);");
+                            w.WriteLine($"w.Write((uint){name}.Count);");
                             w.WriteLine($"foreach (var n in {name})");
                             w.WriteLine("{");
 
@@ -879,11 +876,11 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                     case BoolTypeInfo boolTypeInfo:
                         w.WriteLine($"{name} = r.GetBoolean();");
                         break;
-                    case IntTypeInfo intTypeInfo when (intTypeInfo.IsSigned):
-                        w.WriteLine($"{name} = ({this.GetParameterTypeString(intTypeInfo)})r.GetInt64();");
-                        break;
                     case IntTypeInfo intTypeInfo when (!intTypeInfo.IsSigned):
-                        w.WriteLine($"{name} = ({this.GetParameterTypeString(intTypeInfo)})r.GetUInt64();");
+                        w.WriteLine($"{name} = r.GetUInt{intTypeInfo.Size}();");
+                        break;
+                    case IntTypeInfo intTypeInfo when (intTypeInfo.IsSigned):
+                        w.WriteLine($"{name} = r.GetInt{intTypeInfo.Size}();");
                         break;
                     case FloatTypeInfo floatTypeInfo when (floatTypeInfo.Size == 32):
                         w.WriteLine($"{name} = r.GetFloat32();");
@@ -905,7 +902,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case ListTypeInfo listTypeInfo:
                         {
-                            w.WriteLine("var length = (int)r.GetUInt64();");
+                            w.WriteLine("var length = r.GetUInt32();");
                             w.WriteLine($"{name} = new {this.GetParameterTypeString(listTypeInfo.ElementType)}[length];");
 
                             w.WriteLine($"for (int i = 0; i < {name}.Count; i++)");
@@ -922,7 +919,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator
                         break;
                     case MapTypeInfo mapTypeInfo:
                         {
-                            w.WriteLine("var length = (int)r.GetUInt64();");
+                            w.WriteLine("var length = r.GetUInt32();");
                             w.WriteLine($"{name} = new Dictionary<{this.GetParameterTypeString(mapTypeInfo.KeyType)}, {this.GetParameterTypeString(mapTypeInfo.ValueType)}>();");
                             w.WriteLine($"{this.GetParameterTypeString(mapTypeInfo.KeyType)} t_key = default;");
                             w.WriteLine($"{this.GetParameterTypeString(mapTypeInfo.ValueType)} t_value = default;");

--- a/src/Omnix.Serialization.RocketPack/RocketPackReader.cs
+++ b/src/Omnix.Serialization.RocketPack/RocketPackReader.cs
@@ -30,16 +30,16 @@ namespace Omnix.Serialization.RocketPack
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IMemoryOwner<byte> GetRecyclableMemory(int limit)
         {
-            if (!Varint.TryGetUInt64(_sequence, out ulong length, out var consumed)) throw new FormatException();
+            if (!Varint.TryGetUInt32(_sequence, out uint length, out var consumed)) throw new FormatException();
 
             _sequence = _sequence.Slice(consumed);
 
-            if (length > (ulong)limit) throw new FormatException();
+            if (length > limit) throw new FormatException();
 
             var memoryOwner = _bufferPool.Rent((int)length);
 
-            _sequence.Slice(0, (long)length).CopyTo(memoryOwner.Memory.Span);
-            _sequence = _sequence.Slice((long)length);
+            _sequence.Slice(0, length).CopyTo(memoryOwner.Memory.Span);
+            _sequence = _sequence.Slice(length);
 
             return memoryOwner;
         }
@@ -47,16 +47,16 @@ namespace Omnix.Serialization.RocketPack
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyMemory<byte> GetMemory(int limit)
         {
-            if (!Varint.TryGetUInt64(_sequence, out ulong length, out var consumed)) throw new FormatException();
+            if (!Varint.TryGetUInt32(_sequence, out uint length, out var consumed)) throw new FormatException();
 
             _sequence = _sequence.Slice(consumed);
 
-            if (length > (ulong)limit) throw new FormatException();
+            if (length > limit) throw new FormatException();
 
             var result = new byte[(int)length];
 
-            _sequence.Slice(0, (long)length).CopyTo(result.AsSpan());
-            _sequence = _sequence.Slice((long)length);
+            _sequence.Slice(0, length).CopyTo(result.AsSpan());
+            _sequence = _sequence.Slice(length);
 
             return new ReadOnlyMemory<byte>(result);
         }
@@ -64,16 +64,16 @@ namespace Omnix.Serialization.RocketPack
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string GetString(int limit)
         {
-            if (!Varint.TryGetUInt64(_sequence, out ulong length, out var consumed)) throw new FormatException();
+            if (!Varint.TryGetUInt32(_sequence, out uint length, out var consumed)) throw new FormatException();
 
             _sequence = _sequence.Slice(consumed);
 
-            if (length > (ulong)limit) throw new FormatException();
+            if (length > limit) throw new FormatException();
 
             using (var memoryOwner = _bufferPool.Rent((int)length))
             {
-                _sequence.Slice(0, (long)length).CopyTo(memoryOwner.Memory.Span);
-                _sequence = _sequence.Slice((long)length);
+                _sequence.Slice(0, length).CopyTo(memoryOwner.Memory.Span);
+                _sequence = _sequence.Slice(length);
 
                 return _encoding.Value.GetString(memoryOwner.Memory.Span);
             }
@@ -102,6 +102,66 @@ namespace Omnix.Serialization.RocketPack
         public ulong GetUInt64()
         {
             if (!Varint.TryGetUInt64(_sequence, out ulong result, out var consumed)) throw new FormatException();
+
+            _sequence = _sequence.Slice(consumed);
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public byte GetUInt8()
+        {
+            if (!Varint.TryGetUInt8(_sequence, out byte result, out var consumed)) throw new FormatException();
+
+            _sequence = _sequence.Slice(consumed);
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ushort GetUInt16()
+        {
+            if (!Varint.TryGetUInt16(_sequence, out ushort result, out var consumed)) throw new FormatException();
+
+            _sequence = _sequence.Slice(consumed);
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public uint GetUInt32()
+        {
+            if (!Varint.TryGetUInt32(_sequence, out uint result, out var consumed)) throw new FormatException();
+
+            _sequence = _sequence.Slice(consumed);
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public sbyte GetInt8()
+        {
+            if (!Varint.TryGetInt8(_sequence, out sbyte result, out var consumed)) throw new FormatException();
+
+            _sequence = _sequence.Slice(consumed);
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public short GetInt16()
+        {
+            if (!Varint.TryGetInt16(_sequence, out short result, out var consumed)) throw new FormatException();
+
+            _sequence = _sequence.Slice(consumed);
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetInt32()
+        {
+            if (!Varint.TryGetInt32(_sequence, out int result, out var consumed)) throw new FormatException();
 
             _sequence = _sequence.Slice(consumed);
 

--- a/src/Omnix.Serialization.RocketPack/RocketPackWriter.cs
+++ b/src/Omnix.Serialization.RocketPack/RocketPackWriter.cs
@@ -31,7 +31,7 @@ namespace Omnix.Serialization.RocketPack
             using (var memoryOwner = _bufferPool.Rent(_encoding.Value.GetMaxByteCount(value.Length)))
             {
                 int length = _encoding.Value.GetBytes(value.AsSpan(), memoryOwner.Memory.Span);
-                Varint.SetUInt64((uint)length, _bufferWriter);
+                Varint.SetUInt32((uint)length, _bufferWriter);
 
                 _bufferWriter.Write(memoryOwner.Memory.Span.Slice(0, length));
             }
@@ -40,7 +40,7 @@ namespace Omnix.Serialization.RocketPack
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(ReadOnlySpan<byte> value)
         {
-            Varint.SetUInt64((uint)value.Length, _bufferWriter);
+            Varint.SetUInt32((uint)value.Length, _bufferWriter);
             _bufferWriter.Write(value);
         }
 
@@ -48,25 +48,62 @@ namespace Omnix.Serialization.RocketPack
         public void Write(Timestamp value)
         {
             this.Write((long)value.Seconds);
-            this.Write((ulong)value.Nanos);
+            this.Write((uint)value.Nanos);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(bool value)
         {
-            this.Write((ulong)(!value ? (byte)0x00 : (byte)0x01));
+            _bufferWriter.GetSpan(1)[0] = !value ? (byte)0x00 : (byte)0x01;
+            _bufferWriter.Advance(1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Write(long value)
+        public void Write(byte value)
         {
-            Varint.SetInt64(value, _bufferWriter);
+            Varint.SetUInt64(value, _bufferWriter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(ushort value)
+        {
+            Varint.SetUInt64(value, _bufferWriter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(uint value)
+        {
+            Varint.SetUInt64(value, _bufferWriter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(ulong value)
         {
             Varint.SetUInt64(value, _bufferWriter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(sbyte value)
+        {
+            Varint.SetInt64(value, _bufferWriter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(short value)
+        {
+            Varint.SetInt64(value, _bufferWriter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(int value)
+        {
+            Varint.SetInt64(value, _bufferWriter);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(long value)
+        {
+            Varint.SetInt64(value, _bufferWriter);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Omnix.Serialization/Omnix.Serialization.csproj
+++ b/src/Omnix.Serialization/Omnix.Serialization.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Omnix.Base.Tests/Omnix.Base.Tests.csproj
+++ b/tests/Omnix.Base.Tests/Omnix.Base.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Collections.Tests/Omnix.Collections.Tests.csproj
+++ b/tests/Omnix.Collections.Tests/Omnix.Collections.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Cryptography.Tests/Omnix.Cryptography.Tests.csproj
+++ b/tests/Omnix.Cryptography.Tests/Omnix.Cryptography.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.4.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Io.Tests/Omnix.Io.Tests.csproj
+++ b/tests/Omnix.Io.Tests/Omnix.Io.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Network.Connection.Tests/Omnix.Network.Connection.Tests.csproj
+++ b/tests/Omnix.Network.Connection.Tests/Omnix.Network.Connection.Tests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Network.Upnp.Tests/Omnix.Network.Upnp.Tests.csproj
+++ b/tests/Omnix.Network.Upnp.Tests/Omnix.Network.Upnp.Tests.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Serialization.RocketPack.CodeGenerator.Tests/Internal/_RocketPack/Messages.generated.cs
+++ b/tests/Omnix.Serialization.RocketPack.CodeGenerator.Tests/Internal/_RocketPack/Messages.generated.cs
@@ -233,7 +233,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.X0 != default) propertyCount++;
                     if (value.X1 != default) propertyCount++;
                     if (value.X2 != default) propertyCount++;
@@ -259,152 +259,152 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                     if (!value.X22.IsEmpty) propertyCount++;
                     if (value.X23.Count != 0) propertyCount++;
                     if (value.X24.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // X0
                 if (value.X0 != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.X0);
                 }
                 // X1
                 if (value.X1 != default)
                 {
-                    w.Write((ulong)1);
-                    w.Write((long)value.X1);
+                    w.Write((uint)1);
+                    w.Write(value.X1);
                 }
                 // X2
                 if (value.X2 != default)
                 {
-                    w.Write((ulong)2);
-                    w.Write((long)value.X2);
+                    w.Write((uint)2);
+                    w.Write(value.X2);
                 }
                 // X3
                 if (value.X3 != default)
                 {
-                    w.Write((ulong)3);
-                    w.Write((long)value.X3);
+                    w.Write((uint)3);
+                    w.Write(value.X3);
                 }
                 // X4
                 if (value.X4 != default)
                 {
-                    w.Write((ulong)4);
-                    w.Write((long)value.X4);
+                    w.Write((uint)4);
+                    w.Write(value.X4);
                 }
                 // X5
                 if (value.X5 != default)
                 {
-                    w.Write((ulong)5);
-                    w.Write((ulong)value.X5);
+                    w.Write((uint)5);
+                    w.Write(value.X5);
                 }
                 // X6
                 if (value.X6 != default)
                 {
-                    w.Write((ulong)6);
-                    w.Write((ulong)value.X6);
+                    w.Write((uint)6);
+                    w.Write(value.X6);
                 }
                 // X7
                 if (value.X7 != default)
                 {
-                    w.Write((ulong)7);
-                    w.Write((ulong)value.X7);
+                    w.Write((uint)7);
+                    w.Write(value.X7);
                 }
                 // X8
                 if (value.X8 != default)
                 {
-                    w.Write((ulong)8);
-                    w.Write((ulong)value.X8);
+                    w.Write((uint)8);
+                    w.Write(value.X8);
                 }
                 // X9
                 if (value.X9 != default)
                 {
-                    w.Write((ulong)9);
+                    w.Write((uint)9);
                     w.Write((long)value.X9);
                 }
                 // X10
                 if (value.X10 != default)
                 {
-                    w.Write((ulong)10);
+                    w.Write((uint)10);
                     w.Write((long)value.X10);
                 }
                 // X11
                 if (value.X11 != default)
                 {
-                    w.Write((ulong)11);
+                    w.Write((uint)11);
                     w.Write((long)value.X11);
                 }
                 // X12
                 if (value.X12 != default)
                 {
-                    w.Write((ulong)12);
+                    w.Write((uint)12);
                     w.Write((long)value.X12);
                 }
                 // X13
                 if (value.X13 != default)
                 {
-                    w.Write((ulong)13);
+                    w.Write((uint)13);
                     w.Write((ulong)value.X13);
                 }
                 // X14
                 if (value.X14 != default)
                 {
-                    w.Write((ulong)14);
+                    w.Write((uint)14);
                     w.Write((ulong)value.X14);
                 }
                 // X15
                 if (value.X15 != default)
                 {
-                    w.Write((ulong)15);
+                    w.Write((uint)15);
                     w.Write((ulong)value.X15);
                 }
                 // X16
                 if (value.X16 != default)
                 {
-                    w.Write((ulong)16);
+                    w.Write((uint)16);
                     w.Write((ulong)value.X16);
                 }
                 // X17
                 if (value.X17 != default)
                 {
-                    w.Write((ulong)17);
+                    w.Write((uint)17);
                     w.Write(value.X17);
                 }
                 // X18
                 if (value.X18 != default)
                 {
-                    w.Write((ulong)18);
+                    w.Write((uint)18);
                     w.Write(value.X18);
                 }
                 // X19
                 if (value.X19 != default)
                 {
-                    w.Write((ulong)19);
+                    w.Write((uint)19);
                     w.Write(value.X19);
                 }
                 // X20
                 if (value.X20 != default)
                 {
-                    w.Write((ulong)20);
+                    w.Write((uint)20);
                     w.Write(value.X20);
                 }
                 // X21
                 if (!value.X21.IsEmpty)
                 {
-                    w.Write((ulong)21);
+                    w.Write((uint)21);
                     w.Write(value.X21.Span);
                 }
                 // X22
                 if (!value.X22.IsEmpty)
                 {
-                    w.Write((ulong)22);
+                    w.Write((uint)22);
                     w.Write(value.X22.Span);
                 }
                 // X23
                 if (value.X23.Count != 0)
                 {
-                    w.Write((ulong)23);
-                    w.Write((ulong)value.X23.Count);
+                    w.Write((uint)23);
+                    w.Write((uint)value.X23.Count);
                     foreach (var n in value.X23)
                     {
                         w.Write(n);
@@ -413,11 +413,11 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 // X24
                 if (value.X24.Count != 0)
                 {
-                    w.Write((ulong)24);
-                    w.Write((ulong)value.X24.Count);
+                    w.Write((uint)24);
+                    w.Write((uint)value.X24.Count);
                     foreach (var n in value.X24)
                     {
-                        w.Write((ulong)n.Key);
+                        w.Write(n.Key);
                         w.Write(n.Value);
                     }
                 }
@@ -428,7 +428,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 bool p_x0 = default;
                 sbyte p_x1 = default;
@@ -458,7 +458,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // X0
@@ -468,42 +468,42 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                             }
                         case 1: // X1
                             {
-                                p_x1 = (sbyte)r.GetInt64();
+                                p_x1 = r.GetInt8();
                                 break;
                             }
                         case 2: // X2
                             {
-                                p_x2 = (short)r.GetInt64();
+                                p_x2 = r.GetInt16();
                                 break;
                             }
                         case 3: // X3
                             {
-                                p_x3 = (int)r.GetInt64();
+                                p_x3 = r.GetInt32();
                                 break;
                             }
                         case 4: // X4
                             {
-                                p_x4 = (long)r.GetInt64();
+                                p_x4 = r.GetInt64();
                                 break;
                             }
                         case 5: // X5
                             {
-                                p_x5 = (byte)r.GetUInt64();
+                                p_x5 = r.GetUInt8();
                                 break;
                             }
                         case 6: // X6
                             {
-                                p_x6 = (ushort)r.GetUInt64();
+                                p_x6 = r.GetUInt16();
                                 break;
                             }
                         case 7: // X7
                             {
-                                p_x7 = (uint)r.GetUInt64();
+                                p_x7 = r.GetUInt32();
                                 break;
                             }
                         case 8: // X8
                             {
-                                p_x8 = (ulong)r.GetUInt64();
+                                p_x8 = r.GetUInt64();
                                 break;
                             }
                         case 9: // X9
@@ -578,7 +578,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                             }
                         case 23: // X23
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_x23 = new string[length];
                                 for (int i = 0; i < p_x23.Count; i++)
                                 {
@@ -588,13 +588,13 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                             }
                         case 24: // X24
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_x24 = new Dictionary<byte, string>();
                                 byte t_key = default;
                                 string t_value = default;
                                 for (int i = 0; i < length; i++)
                                 {
-                                    t_key = (byte)r.GetUInt64();
+                                    t_key = r.GetUInt8();
                                     t_value = r.GetString(128);
                                     p_x24[t_key] = t_value;
                                 }
@@ -797,21 +797,21 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 // X0
                 w.Write(value.X0);
                 // X1
-                w.Write((long)value.X1);
+                w.Write(value.X1);
                 // X2
-                w.Write((long)value.X2);
+                w.Write(value.X2);
                 // X3
-                w.Write((long)value.X3);
+                w.Write(value.X3);
                 // X4
-                w.Write((long)value.X4);
+                w.Write(value.X4);
                 // X5
-                w.Write((ulong)value.X5);
+                w.Write(value.X5);
                 // X6
-                w.Write((ulong)value.X6);
+                w.Write(value.X6);
                 // X7
-                w.Write((ulong)value.X7);
+                w.Write(value.X7);
                 // X8
-                w.Write((ulong)value.X8);
+                w.Write(value.X8);
                 // X9
                 w.Write((long)value.X9);
                 // X10
@@ -841,16 +841,16 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 // X22
                 w.Write(value.X22.Span);
                 // X23
-                w.Write((ulong)value.X23.Count);
+                w.Write((uint)value.X23.Count);
                 foreach (var n in value.X23)
                 {
                     w.Write(n);
                 }
                 // X24
-                w.Write((ulong)value.X24.Count);
+                w.Write((uint)value.X24.Count);
                 foreach (var n in value.X24)
                 {
-                    w.Write((ulong)n.Key);
+                    w.Write(n.Key);
                     w.Write(n.Value);
                 }
             }
@@ -891,35 +891,35 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 }
                 // X1
                 {
-                    p_x1 = (sbyte)r.GetInt64();
+                    p_x1 = r.GetInt8();
                 }
                 // X2
                 {
-                    p_x2 = (short)r.GetInt64();
+                    p_x2 = r.GetInt16();
                 }
                 // X3
                 {
-                    p_x3 = (int)r.GetInt64();
+                    p_x3 = r.GetInt32();
                 }
                 // X4
                 {
-                    p_x4 = (long)r.GetInt64();
+                    p_x4 = r.GetInt64();
                 }
                 // X5
                 {
-                    p_x5 = (byte)r.GetUInt64();
+                    p_x5 = r.GetUInt8();
                 }
                 // X6
                 {
-                    p_x6 = (ushort)r.GetUInt64();
+                    p_x6 = r.GetUInt16();
                 }
                 // X7
                 {
-                    p_x7 = (uint)r.GetUInt64();
+                    p_x7 = r.GetUInt32();
                 }
                 // X8
                 {
-                    p_x8 = (ulong)r.GetUInt64();
+                    p_x8 = r.GetUInt64();
                 }
                 // X9
                 {
@@ -979,7 +979,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 }
                 // X23
                 {
-                    var length = (int)r.GetUInt64();
+                    var length = r.GetUInt32();
                     p_x23 = new string[length];
                     for (int i = 0; i < p_x23.Count; i++)
                     {
@@ -988,13 +988,13 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 }
                 // X24
                 {
-                    var length = (int)r.GetUInt64();
+                    var length = r.GetUInt32();
                     p_x24 = new Dictionary<byte, string>();
                     byte t_key = default;
                     string t_value = default;
                     for (int i = 0; i < length; i++)
                     {
-                        t_key = (byte)r.GetUInt64();
+                        t_key = r.GetUInt8();
                         t_value = r.GetString(128);
                         p_x24[t_key] = t_value;
                     }
@@ -1058,16 +1058,16 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.List.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // List
                 if (value.List.Count != 0)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.List.Count);
+                    w.Write((uint)0);
+                    w.Write((uint)value.List.Count);
                     foreach (var n in value.List)
                     {
                         IntPropertiesMessage.Formatter.Serialize(w, n, rank + 1);
@@ -1080,18 +1080,18 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IList<IntPropertiesMessage> p_list = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // List
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_list = new IntPropertiesMessage[length];
                                 for (int i = 0; i < p_list.Count; i++)
                                 {
@@ -1160,16 +1160,16 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.List.Count != 0) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // List
                 if (value.List.Count != 0)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.List.Count);
+                    w.Write((uint)0);
+                    w.Write((uint)value.List.Count);
                     foreach (var n in value.List)
                     {
                         StringPropertiesMessage.Formatter.Serialize(w, n, rank + 1);
@@ -1182,18 +1182,18 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 IList<StringPropertiesMessage> p_list = default;
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // List
                             {
-                                var length = (int)r.GetUInt64();
+                                var length = r.GetUInt32();
                                 p_list = new StringPropertiesMessage[length];
                                 for (int i = 0; i < p_list.Count; i++)
                                 {
@@ -1281,7 +1281,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.MyProperty1 != default) propertyCount++;
                     if (value.MyProperty2 != default) propertyCount++;
                     if (value.MyProperty3 != default) propertyCount++;
@@ -1291,62 +1291,62 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                     if (value.MyProperty7 != default) propertyCount++;
                     if (value.MyProperty8 != default) propertyCount++;
                     if (value.MyProperty9 != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // MyProperty1
                 if (value.MyProperty1 != default)
                 {
-                    w.Write((ulong)0);
-                    w.Write((ulong)value.MyProperty1);
+                    w.Write((uint)0);
+                    w.Write(value.MyProperty1);
                 }
                 // MyProperty2
                 if (value.MyProperty2 != default)
                 {
-                    w.Write((ulong)1);
-                    w.Write((ulong)value.MyProperty2);
+                    w.Write((uint)1);
+                    w.Write(value.MyProperty2);
                 }
                 // MyProperty3
                 if (value.MyProperty3 != default)
                 {
-                    w.Write((ulong)2);
-                    w.Write((ulong)value.MyProperty3);
+                    w.Write((uint)2);
+                    w.Write(value.MyProperty3);
                 }
                 // MyProperty4
                 if (value.MyProperty4 != default)
                 {
-                    w.Write((ulong)3);
-                    w.Write((ulong)value.MyProperty4);
+                    w.Write((uint)3);
+                    w.Write(value.MyProperty4);
                 }
                 // MyProperty5
                 if (value.MyProperty5 != default)
                 {
-                    w.Write((ulong)4);
-                    w.Write((ulong)value.MyProperty5);
+                    w.Write((uint)4);
+                    w.Write(value.MyProperty5);
                 }
                 // MyProperty6
                 if (value.MyProperty6 != default)
                 {
-                    w.Write((ulong)5);
-                    w.Write((ulong)value.MyProperty6);
+                    w.Write((uint)5);
+                    w.Write(value.MyProperty6);
                 }
                 // MyProperty7
                 if (value.MyProperty7 != default)
                 {
-                    w.Write((ulong)6);
-                    w.Write((ulong)value.MyProperty7);
+                    w.Write((uint)6);
+                    w.Write(value.MyProperty7);
                 }
                 // MyProperty8
                 if (value.MyProperty8 != default)
                 {
-                    w.Write((ulong)7);
-                    w.Write((ulong)value.MyProperty8);
+                    w.Write((uint)7);
+                    w.Write(value.MyProperty8);
                 }
                 // MyProperty9
                 if (value.MyProperty9 != default)
                 {
-                    w.Write((ulong)8);
-                    w.Write((ulong)value.MyProperty9);
+                    w.Write((uint)8);
+                    w.Write(value.MyProperty9);
                 }
             }
 
@@ -1355,7 +1355,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 uint p_myProperty1 = default;
                 uint p_myProperty2 = default;
@@ -1369,52 +1369,52 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // MyProperty1
                             {
-                                p_myProperty1 = (uint)r.GetUInt64();
+                                p_myProperty1 = r.GetUInt32();
                                 break;
                             }
                         case 1: // MyProperty2
                             {
-                                p_myProperty2 = (uint)r.GetUInt64();
+                                p_myProperty2 = r.GetUInt32();
                                 break;
                             }
                         case 2: // MyProperty3
                             {
-                                p_myProperty3 = (uint)r.GetUInt64();
+                                p_myProperty3 = r.GetUInt32();
                                 break;
                             }
                         case 3: // MyProperty4
                             {
-                                p_myProperty4 = (uint)r.GetUInt64();
+                                p_myProperty4 = r.GetUInt32();
                                 break;
                             }
                         case 4: // MyProperty5
                             {
-                                p_myProperty5 = (uint)r.GetUInt64();
+                                p_myProperty5 = r.GetUInt32();
                                 break;
                             }
                         case 5: // MyProperty6
                             {
-                                p_myProperty6 = (uint)r.GetUInt64();
+                                p_myProperty6 = r.GetUInt32();
                                 break;
                             }
                         case 6: // MyProperty7
                             {
-                                p_myProperty7 = (uint)r.GetUInt64();
+                                p_myProperty7 = r.GetUInt32();
                                 break;
                             }
                         case 7: // MyProperty8
                             {
-                                p_myProperty8 = (uint)r.GetUInt64();
+                                p_myProperty8 = r.GetUInt32();
                                 break;
                             }
                         case 8: // MyProperty9
                             {
-                                p_myProperty9 = (uint)r.GetUInt64();
+                                p_myProperty9 = r.GetUInt32();
                                 break;
                             }
                     }
@@ -1484,29 +1484,29 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 // Write property count
                 {
-                    int propertyCount = 0;
+                    uint propertyCount = 0;
                     if (value.MyProperty1 != default) propertyCount++;
                     if (value.MyProperty2 != default) propertyCount++;
                     if (value.MyProperty3 != default) propertyCount++;
-                    w.Write((ulong)propertyCount);
+                    w.Write(propertyCount);
                 }
 
                 // MyProperty1
                 if (value.MyProperty1 != default)
                 {
-                    w.Write((ulong)0);
+                    w.Write((uint)0);
                     w.Write(value.MyProperty1);
                 }
                 // MyProperty2
                 if (value.MyProperty2 != default)
                 {
-                    w.Write((ulong)1);
+                    w.Write((uint)1);
                     w.Write(value.MyProperty2);
                 }
                 // MyProperty3
                 if (value.MyProperty3 != default)
                 {
-                    w.Write((ulong)2);
+                    w.Write((uint)2);
                     w.Write(value.MyProperty3);
                 }
             }
@@ -1516,7 +1516,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
                 if (rank > 256) throw new FormatException();
 
                 // Read property count
-                int propertyCount = (int)r.GetUInt64();
+                uint propertyCount = r.GetUInt32();
 
                 string p_myProperty1 = default;
                 string p_myProperty2 = default;
@@ -1524,7 +1524,7 @@ namespace Omnix.Serialization.RocketPack.CodeGenerator.Tests.Internal
 
                 for (; propertyCount > 0; propertyCount--)
                 {
-                    int id = (int)r.GetUInt64();
+                    uint id = r.GetUInt32();
                     switch (id)
                     {
                         case 0: // MyProperty1

--- a/tests/Omnix.Serialization.RocketPack.CodeGenerator.Tests/Omnix.Serialization.RocketPack.CodeGenerator.Tests.csproj
+++ b/tests/Omnix.Serialization.RocketPack.CodeGenerator.Tests/Omnix.Serialization.RocketPack.CodeGenerator.Tests.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Serialization.Tests/Omnix.Serialization.Tests.csproj
+++ b/tests/Omnix.Serialization.Tests/Omnix.Serialization.Tests.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Omnix.Serialization.Tests/VarintTests.cs
+++ b/tests/Omnix.Serialization.Tests/VarintTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Omnix.Base;
+using Xunit;
+
+namespace Omnix.Serialization.Tests
+{
+    public class VarintTests
+    {
+        [Fact]
+        public void RandomTest()
+        {
+            var random = new Random();
+            var hub = new Hub();
+
+            for (int i = 0; i < 1024; i++)
+            {
+                var result1 = ((ulong)random.Next() << 32) | (ulong)random.Next();
+
+                Varint.SetUInt64(result1, hub.Writer);
+                hub.Writer.Complete();
+
+                Varint.TryGetUInt64(hub.Reader.GetSequence(), out var result2, out var _);
+                hub.Reader.Complete();
+
+                Assert.Equal(result1, result2);
+                hub.Reset();
+            }
+        }
+    }
+}


### PR DESCRIPTION
ベンチマークの結果、「Protocol Buffers」のフォーマットより優れていることが確認できた。